### PR TITLE
preserve UTC, using calendar.timegm()

### DIFF
--- a/spool/spoolex.py
+++ b/spool/spoolex.py
@@ -1,5 +1,5 @@
 import binascii
-import time
+import calendar
 
 from collections import namedtuple, defaultdict
 from exceptions import Exception
@@ -176,4 +176,4 @@ class BlockchainSpider(object):
         :return: unix timestamp
         """
         dt = datetime.strptime(time_utc_str, "%Y-%m-%dT%H:%M:%SZ")
-        return int(time.mktime(dt.utctimetuple()))
+        return int(calendar.timegm(dt.utctimetuple()))

--- a/tests/test_blockchain_spider.py
+++ b/tests/test_blockchain_spider.py
@@ -57,7 +57,7 @@ class TestBlockchainSpider(unittest.TestCase):
                                          'from_address': u'mqXz83H4LCxjf2ie8hYNsTRByvtfV43Pa7',
                                          'number_editions': 10,
                                          'piece_address': u'myr2VcDnPKf997sjXx6rUFc4CtFH9sxNVS',
-                                         'timestamp_utc': 1432646255,
+                                         'timestamp_utc': 1432649855,
                                          'to_address': u'n2sQHoUghWUgSM8msqdmCim8pZ635YjoCD',
                                          'txid': u'fb22bbb83161f6904f1803ee1cdbed1b5836eb9ac51b102564400989780b48ea',
                                          'verb': 'ASCRIBESPOOL01EDITIONS10'},
@@ -66,7 +66,7 @@ class TestBlockchainSpider(unittest.TestCase):
                                         'from_address': u'mqXz83H4LCxjf2ie8hYNsTRByvtfV43Pa7',
                                         'number_editions': 10,
                                         'piece_address': u'myr2VcDnPKf997sjXx6rUFc4CtFH9sxNVS',
-                                        'timestamp_utc': 1432647405,
+                                        'timestamp_utc': 1432651005,
                                         'to_address': u'n2sQHoUghWUgSM8msqdmCim8pZ635YjoCD',
                                         'txid': u'02994a3ceee87be2210fa6e4a649bc0626e791f590bd8db22e7e1fd9fc66d038',
                                         'verb': 'ASCRIBESPOOL01REGISTER0'}]})


### PR DESCRIPTION
**NOTE**: I assumed that it is the intention to preserve the UTC all along ...

Using `mktime()` will give different results depending on the timezone the host is set to. For instance, the expected `timestamp_utc` values that are in `tests.TestBlockchainSpider.test_data()` will work when running the test on a host for which the timezone is set to Europe/Berlin, but will fail on a host for which the timezone is set to America/New York ...

The table below is from Python's docs (https://docs.python.org/2/library/time.html#module-time) ...

| From | To | Use |
| --- | --- | --- |
| seconds since the epoch | `struct_time` in UTC | `gmtime()` |
| seconds since the epoch | `struct_time` in local time | `localtime()` |
| `struct_time` in UTC | seconds since the epoch | `calendar.timegm()` |
| `struct_time` in local time | seconds since the epoch | `mktime()` |
